### PR TITLE
DOC: Add paper link to README, and citation; fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,64 @@
 # mMAN_lesions
 codes for manuscript published in eLife titled 'Lesions in a songbird vocal circuit increase variability in song syntax'
 
-# Sourcedata1:
+Paper: https://elifesciences.org/articles/93272
+
+## Usage
+### Sourcedata1:
 Sequence data of all birds with introductory notes and repeats replaced (bird<birdnumber>_<prelesion or postlesion>_REPR) and with only introductory notes replaced (bird<birdnumber>_<prelesion or postlesion>)
-# Figure3_figuresupplement1_sourcedata1:
+### Figure3_figuresupplement1_sourcedata1:
 Median gap durations and transition entropy data for generating Figure 3- figure supplement 1
-# Figure2_figuresupplement4_sourcedata1 :
+### Figure2_figuresupplement4_sourcedata1 :
 Spectral features data for generating Figure 2-figure supplement 4
 
 
-# Figure2_SourceCode1:
+### Figure2_SourceCode1:
 Code for generating Figure 2D based on data from Sourcedata1
-# Figure2_figuresupplement4_sourcecode1
+### Figure2_figuresupplement4_sourcecode1
 Code for generating Figure 2- figure supplement 4 based on data from Figure2_figuresupplement4_sourcedata1 
-# Figure2_figuresupplement5_sourcecode1
+### Figure2_figuresupplement5_sourcecode1
 Code for generating Figure 2-figure supplement 5 B based on data from Sourcedata1
-# Figure2_figuresupplement5_sourcecode2
+### Figure2_figuresupplement5_sourcecode2
 Code for generating Figure 2-figure supplement 5A based on data from Sourcedata1
-# Figure3_SourceCode1
+### Figure3_SourceCode1
 Code for generating Figure 3D based on data from Sourcedata1
-# Figure3_SourceCode2
+### Figure3_SourceCode2
 Code for generating Figure 3B and 3C based on data from Sourcedata1
-# Figure3_figuresupplement1_sourcecode1
+### Figure3_figuresupplement1_sourcecode1
 Code for generating Figure 3-figure supplement 1 based on data from Figure3_figuresupplement1_sourceddata1
-# Figure4_SourceCode1
+### Figure4_SourceCode1
 Code for generating Figure 4B based on data from Sourcedata1
-# Figure4_SourceCode2
+### Figure4_SourceCode2
 Code for generating Figure 4D based on data from Sourcedata1
 Figure4_SourceCode3
 Code for generating Figure 4C based on data from Sourcedata1
-# Source_Code1
+### Source_Code1
 Helper functions auxillary to all codes used in this paper
 
+## Citation
+To cite the paper:  
+Avani Koparkar, Timothy L Warren, Jonathan D Charlesworth, Sooyoon Shin, Michael S Brainard, Lena Veit 
+(2024) **Lesions in a songbird vocal circuit increase variability in song syntax** *eLife* **13**:RP93272.
+
+Bibtex:
+```
+@article {10.7554/eLife.93272,
+article_type = {journal},
+title = {Lesions in a songbird vocal circuit increase variability in song syntax},
+author = {Koparkar, Avani and Warren, Timothy L and Charlesworth, Jonathan D and Shin, Sooyoon and Brainard, Michael S and Veit, Lena},
+editor = {Goldberg, Jesse H and King, Andrew J},
+volume = 13,
+year = 2024,
+month = {apr},
+pub_date = {2024-04-18},
+pages = {RP93272},
+citation = {eLife 2024;13:RP93272},
+doi = {10.7554/eLife.93272},
+url = {https://doi.org/10.7554/eLife.93272},
+abstract = {Complex skills like speech and dance are composed of ordered sequences of simpler elements, but the neuronal basis for the syntactic ordering of actions is poorly understood. Birdsong is a learned vocal behavior composed of syntactically ordered syllables, controlled in part by the songbird premotor nucleus HVC (proper name). Here, we test whether one of HVC’s recurrent inputs, mMAN (medial magnocellular nucleus of the anterior nidopallium), contributes to sequencing in adult male Bengalese finches (\textit{Lonchura striata domestica}). Bengalese finch song includes several patterns: (1) \textit{chunks,} comprising stereotyped syllable sequences; (2) \textit{branch points}, where a given syllable can be followed probabilistically by multiple syllables; and (3) \textit{repeat phrases}, where individual syllables are repeated variable numbers of times. We found that following bilateral lesions of mMAN, acoustic structure of syllables remained largely intact, but sequencing became more variable, as evidenced by ‘breaks’ in previously stereotyped chunks, increased uncertainty at branch points, and increased variability in repeat numbers. Our results show that mMAN contributes to the variable sequencing of vocal elements in Bengalese finch song and demonstrate the influence of recurrent projections to HVC. Furthermore, they highlight the utility of species with complex syntax in investigating neuronal control of ordered sequences.},
+keywords = {songbird, Bengalese finch, \textit{Lonchura striata domestica}},
+journal = {eLife},
+issn = {2050-084X},
+publisher = {eLife Sciences Publications, Ltd},
+}
+```


### PR DESCRIPTION
Hi @avanikop, this adds a link to the paper at the top of the README. Fixes issue #1.

It also divides the README into two sections, "Usage", that has your explanations of the data + code, and "Citation" at the bottom, with a plaintext and bibtex citation for the paper